### PR TITLE
flows.f90: changed peak_lat to sin(peak_lat)

### DIFF
--- a/src/flows.f90
+++ b/src/flows.f90
@@ -51,7 +51,7 @@ CONTAINS
  REAL(dp) :: P, du, peak_lat
  REAL(dp), INTENT(out) :: MC_vel(0:nthUnif-2)
 
- P = (1.0_dp/(peak_lat*PI/180.0_dp)**2) - 1.0_dp
+ P = (1.0_dp/(DSIN(peak_lat*PI/180.0_dp))**2) - 1.0_dp
  du = C*(1E-3)*((1.0_dp+P)**(0.5_dp*(P+1)))/(P**(P*0.5_dp))
  MC_vel = du*sg*(SQRT(1.0_dp - sg**2))**(P)
  


### PR DESCRIPTION
Yeates(2020) calculates peak latitude of meridional flow profile in Appendix B. This formula for peak latitude is actually one for the sine of the peak latitude (see first paragraph of Appendix B). So in flows.f90, calculating p from the input peak_lat should account for this sine.